### PR TITLE
Handle case where destination does not exist yet

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,16 @@ export const cli = fibrous((argv: CustomArgv) => {
       const srcVersions = npm.sync.get(srcUrl, srcConfig).versions;
 
       logger.info("Getting versions from destination...", "📡");
-      const destVersions = npm.sync.get(destUrl, destConfig).versions;
+      let destVersions;
+      try {
+        destVersions = npm.sync.get(destUrl, destConfig).versions;
+      } catch (e) {
+        destVersions = {};
+        
+        if (e.code !== "E404") {
+          throw e;
+        }
+      }
 
       const srcKeys = Object.keys(srcVersions);
       const destKeys = Object.keys(destVersions);


### PR DESCRIPTION
### Issues Fixed :wrench:
- https://github.com/dperuo/npm-carbon/issues/5
  If the publish destination doesn't yet exist, it's okay because we're going to create it. We can catch the HTTP404 and sync all the versions.

### Breaking Changes :boom:
None

### Details :memo:
This was ported from the the original `npm-copy` behaviour: https://github.com/goodeggs/npm-copy/blob/master/src/cli.coffee#L33

I've tested this change and was able to successfully sync a package from npm to the GitHub package registry. The sync failed with the master branch due to the package not existing in GitHub package registry yet.

<!-- Please add labels to this PR! -->
